### PR TITLE
Rework to replace length with ethertype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ LIBS= -pthread -L ./libs/libcli -lcli
 OBJS=objs/graph.o \
 	 objs/net.o	 \
 	 objs/nwcli.o \
-	 objs/comm.o
+	 objs/comm.o \
+	 objs/layer2/layer2.o
 
 test.out:init objs/testapp.o ${OBJS} libs/libcli/libcli.so.1.10
 	${CC} ${CCDEBUGFLAGS} objs/testapp.o ${OBJS} -o test.out ${LIBS}
 
 init:
-	mkdir -p objs
+	mkdir -p objs/layer2
 
 objs/testapp.o:src/testapp.cc
 	${CC} ${CCDEBUGFLAGS} -c src/testapp.cc -o objs/testapp.o
@@ -28,6 +29,10 @@ objs/nwcli.o:src/nwcli.cc
 
 objs/comm.o:src/comm.cc
 	${CC} ${CCDEBUGFLAGS} -c -I . src/comm.cc -o objs/comm.o
+
+objs/layer2/layer2.o:src/layer2/layer2.cc
+	${CC} ${CCDEBUGFLAGS} -c -I . src/layer2/layer2.cc -o objs/layer2/layer2.o
+
 
 libs/libcli/libcli.so.1.10:
 	(cd libs/libcli; make)

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -3,10 +3,11 @@
 
 #include "comm.hh"
 #include "nwcli.hh"
+#include "layer2/layer2.hh"
 
 extern cli_def* cli;
 
-static unsigned short udp_port_number = 10000;
+static unsigned short udp_port_number = UDP_PORT_START;
 unsigned char recv_buffer[MAX_AUX_INFO_SIZE + MAX_PKT_BUFFER_SIZE];
 
 static unsigned short get_next_udp_port_number () {
@@ -36,7 +37,10 @@ void init_udp_socket (node_t *node) {
 
 // Entry point into data link layer from physical layer, ingress journey of packet starts from here in the TCP/IP stack
 int pkt_receive (node_t *node, interface_t *intf, unsigned char *pkt, unsigned short pkt_size) {
-	printf("msg received = '%s', on node = %s, ingress intf = %s\n", pkt, node -> node_name, intf -> intf_name);
+	//printf("msg received = '%s', on node = %s, ingress intf = %s\n", pkt, node -> node_name, intf -> intf_name);
+	pkt = pkt_buffer_shift_right(pkt, pkt_size, MAX_PKT_BUFFER_SIZE);
+	
+	l2_frame_recv(node, intf, pkt, pkt_size);
 	return 0;
 }
 

--- a/src/config.hh
+++ b/src/config.hh
@@ -14,6 +14,7 @@
 // comm
 #define MAX_PKT_BUFFER_SIZE 2048
 #define MAX_AUX_INFO_SIZE INTF_NAME_SIZE
+#define UDP_PORT_START 10000
 
 // nwcli
 #define TELNET_PORT 10023

--- a/src/layer2/ethernet.hh
+++ b/src/layer2/ethernet.hh
@@ -11,18 +11,30 @@ struct ethernet_hdr_t {
 	unsigned short ethertype; // [1536..65535]
 	unsigned char payload[MAX_PAYLOAD_SIZE]; // [46..1500] 
 	unsigned int fcs; // checksum
-	
-	// TODO : impl fcs
-	static unsigned int generate_fcs (unsigned char *payload, unsigned short _payload_length, mac_addr_t* d_addr, mac_addr_t* s_addr) {
-		return 0;
-	}
 };
 #pragma pack(pop)
 
+// TODO : impl fcs
+static unsigned int generate_fcs (unsigned char *payload, unsigned short payload_length, mac_addr_t* d_addr, mac_addr_t* s_addr) {
+	return 0;
+}
 
 // HELPER
 static inline ethernet_hdr_t *alloc_eth_hdr_with_payload (unsigned char *pkt, unsigned short pkt_size) {
-	
+	if (pkt_size > 1500) return nullptr;
+	ethernet_hdr_t *hdr = (ethernet_hdr_t *)malloc(sizeof(ethernet_hdr_t));
+	memset(hdr, 0, sizeof(ethernet_hdr_t));
+	memcpy(&(hdr -> payload), pkt, pkt_size);
+	return hdr;
+}
+
+static inline ethernet_hdr_t *init_ethernet_hdr (mac_addr_t *d_mac, mac_addr_t *s_mac, unsigned short ethertype, unsigned char *pkt, unsigned short pkt_size) {
+	ethernet_hdr_t *hdr = alloc_eth_hdr_with_payload(pkt, pkt_size);
+	memcpy(&hdr -> dst_addr, d_mac, sizeof(mac_addr_t));
+	memcpy(&hdr -> src_addr, s_mac, sizeof(mac_addr_t));
+	hdr -> ethertype = ethertype;
+	hdr -> fcs = generate_fcs(pkt, pkt_size, d_mac, s_mac);
+	return hdr;
 }
 
 static inline bool l2_frame_recv_qualify_on_intf (interface_t *intf, ethernet_hdr_t *hdr) {

--- a/src/layer2/ethernet.hh
+++ b/src/layer2/ethernet.hh
@@ -3,79 +3,26 @@
 
 #define ETH_HDR_SIZE_EXCL_PAYLOAD (sizeof(mac_addr_t) * 2 + sizeof(unsigned short) + sizeof(unsigned int))
 
+#pragma pack (push, 1)
 struct ethernet_hdr_t {	
 	//char preamble[8]; // alignment bytes with SFD, not used
 	mac_addr_t dst_addr;
 	mac_addr_t src_addr;
-	unsigned short length; // [46..1500]
-	unsigned char* payload; 
-	//char payload[MAX_PAYLOAD_SIZE];
+	unsigned short ethertype; // [1536..65535]
+	unsigned char payload[MAX_PAYLOAD_SIZE]; // [46..1500] 
 	unsigned int fcs; // checksum
 	
 	// TODO : impl fcs
-	static unsigned int generate_fcs (unsigned char *payload, unsigned short length, mac_addr_t* d_addr, mac_addr_t* s_addr) {
+	static unsigned int generate_fcs (unsigned char *payload, unsigned short _payload_length, mac_addr_t* d_addr, mac_addr_t* s_addr) {
 		return 0;
 	}
-
-	ethernet_hdr_t () {
-		payload = nullptr;
-	}
-
-	ethernet_hdr_t (unsigned short length) {
-		payload = (unsigned char *)malloc(sizeof(char) * length);
-	}
-
-	ethernet_hdr_t (unsigned char *pkt, unsigned short pkt_size) {
-		// ASSUMPTION : pkt_size <= MAX_PAYLOAD_SIZE
-		length = pkt_size < MIN_PAYLOAD_SIZE ? MIN_PAYLOAD_SIZE : pkt_size;
-		if (pkt_size < MIN_PAYLOAD_SIZE) {
-			payload = (unsigned char *)malloc(sizeof(char) * MIN_PAYLOAD_SIZE);
-			memcpy(payload, pkt, pkt_size);
-			memset(payload + pkt_size, '\0', MIN_PAYLOAD_SIZE - pkt_size);
-		} else {
-			payload = (unsigned char *)malloc(sizeof(char) * pkt_size);
-			memcpy(payload, pkt, pkt_size);
-		}
-		fcs = generate_fcs(payload, length, &dst_addr, &src_addr);
-	}
-
-	ethernet_hdr_t (mac_addr_t *d_addr, mac_addr_t *s_addr, unsigned char *pkt, unsigned short pkt_size) : ethernet_hdr_t(pkt, pkt_size) {
-		memcpy(&dst_addr, d_addr, sizeof(mac_addr_t));
-		memcpy(&src_addr, s_addr, sizeof(mac_addr_t));
-	}
-
-	void *get_hdr () {
-		unsigned char *hdr = (unsigned char *)malloc(ETH_HDR_SIZE_EXCL_PAYLOAD + length);
-		memcpy(hdr, &dst_addr, sizeof(mac_addr_t));
-		memcpy(hdr + sizeof(mac_addr_t), &src_addr, sizeof(mac_addr_t));
-		memcpy(hdr + 2 * sizeof(mac_addr_t), &length, sizeof(unsigned short));
-		memcpy(hdr + 2 * sizeof(mac_addr_t) + sizeof(unsigned short), payload, sizeof(unsigned char) * length);
-		memcpy(hdr + 2 * sizeof(mac_addr_t) + sizeof(unsigned short) + sizeof(unsigned char) * length, &fcs, sizeof(unsigned int));
-		return (void *)hdr;
-	}
-
-	void restore_ethernet_hdr_t (void *plain_hdr) {
-		unsigned char *hdr = (unsigned char *)plain_hdr;
-		memcpy(&dst_addr, hdr, sizeof(mac_addr_t));
-		memcpy(&src_addr, hdr + sizeof(mac_addr_t), sizeof(mac_addr_t));
-		memcpy(&length, hdr + 2 * sizeof(mac_addr_t), sizeof(unsigned short));
-		if (payload) free(payload);
-		payload = (unsigned char *)malloc(sizeof(unsigned char) * length);
-		memcpy(payload, hdr + 2 * sizeof(mac_addr_t) + sizeof(unsigned short), sizeof(unsigned char) * length);
-		memcpy(&fcs, hdr + 2 * sizeof(mac_addr_t) + sizeof(unsigned short) + sizeof(unsigned char) * length, sizeof(unsigned int));
-		free(plain_hdr);
-	}	
-
-	~ethernet_hdr_t () {
-		free(payload);
-	}
-
 };
+#pragma pack(pop)
 
 
 // HELPER
 static inline ethernet_hdr_t *alloc_eth_hdr_with_payload (unsigned char *pkt, unsigned short pkt_size) {
-	return new ethernet_hdr_t(pkt, pkt_size);
+	
 }
 
 static inline bool l2_frame_recv_qualify_on_intf (interface_t *intf, ethernet_hdr_t *hdr) {

--- a/src/layer2/layer2.cc
+++ b/src/layer2/layer2.cc
@@ -1,0 +1,11 @@
+#ifndef LAYER2_CC
+#define LAYER2_CC
+
+#include "layer2.hh"
+
+void l2_frame_recv (node_t *node, interface_t *intf, unsigned char *pkt, unsigned int pkt_size) {
+
+}
+
+
+#endif

--- a/src/layer2/layer2.hh
+++ b/src/layer2/layer2.hh
@@ -10,4 +10,6 @@
 #include "arp.hh"
 #include "ethernet.hh"
 
+void l2_frame_recv (node_t *node, interface_t *intf, unsigned char *pkt, unsigned int pkt_size);
+
 #endif

--- a/src/net.cc
+++ b/src/net.cc
@@ -59,6 +59,11 @@ void intf_assign_mac_addr (interface_t *intf) {
 		(intf) -> intf_nw_props.mac_addr.addr[i] = rand() % 256;
 }
 
+unsigned char *pkt_buffer_shift_right (unsigned char *pkt, unsigned int pkt_size, unsigned int buffer_size) {
+	memcpy(pkt + (buffer_size - pkt_size), pkt, pkt_size);
+	memset(pkt, 0, pkt_size);
+	return pkt + (buffer_size - pkt_size);
+}
 
 // DEBUG IMPL
 void dump_node_nw_props (node_t *node) {

--- a/src/net.hh
+++ b/src/net.hh
@@ -120,6 +120,8 @@ void intf_assign_mac_addr (interface_t *intf);
 
 interface_t *node_get_matching_subnet_intf (node_t *node, ip_addr_t *ip_addr);
 
+unsigned char *pkt_buffer_shift_right (unsigned char *pkt, unsigned int pkt_size, unsigned int buffer_size);
+
 // DEBUG
 
 void dump_node_nw_props (node_t *node);

--- a/src/testapp.cc
+++ b/src/testapp.cc
@@ -48,16 +48,12 @@ static inline void check_size () {
 static inline void ethernet_hdr_check () {
 	char msg[] = "Hello World!Hello World!Hello World!Hello World!";
 	unsigned short msg_size = 49;
-	ethernet_hdr_t *hdr = new ethernet_hdr_t(new mac_addr_t(1,1,1,1,1,1), new mac_addr_t(2,2,2,2,2,2), (unsigned char *)&msg[0], msg_size);
-	void* plain_hdr = hdr -> get_hdr();
+	ethernet_hdr_t *hdr = init_ethernet_hdr(new mac_addr_t(1,1,1,1,1,1), new mac_addr_t(2,2,2,2,2,2), 0x0800, (unsigned char *)&msg[0], msg_size);
+	unsigned char *plain_hdr = (unsigned char *)hdr;
 	for (unsigned int i = 0; i < ETH_HDR_SIZE_EXCL_PAYLOAD + msg_size; i++) 
 		printf("%02X ", *((unsigned char *)plain_hdr + i));
 	printf("\n");
-	delete hdr;
-	ethernet_hdr_t *n_hdr = new ethernet_hdr_t();
-	n_hdr -> restore_ethernet_hdr_t(plain_hdr);
-	printf("recovered payload = %s, ", n_hdr -> payload);
-	printf("recovered msg size = %hu\n", n_hdr -> length);
+	free(hdr);
 }
 
 int main (int argc, char **argv) {


### PR DESCRIPTION
# Diff between `Ethernet II` / `IEEE 802.3`

Picked `Ethernet II` (ethertype) over `lEEE 802.3` (length)

PHY layer will deal with End-of-Packet